### PR TITLE
add option to specify yadda version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ This adds yadda to your node modules and your bower plugins. It also adds the fo
 
 running `ember serve` will make the test results available at `http://localhost:4200/tests`
 
+##### Specifying the yadda version
+
+After installation the addon will have added the most recent yadda version to your bower dependencies. As it comes with
+all yadda releases in its dist folder, you can specify which yadda version to include in your ember-cli build:
+
+```js
+// ember-cli-build.js
+
+    var app = new EmberApp({
+        'ember-cli-yadda': {
+            'yaddaVersion': '0.17.6'
+        }
+    });
+
+```
+
 ## Usage
 This ember-cli addon provides you with two blueprints with which you can create feature files.
 

--- a/blueprints/main-index.js
+++ b/blueprints/main-index.js
@@ -16,7 +16,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addBowerPackagesToProject([
-      { name: 'yadda',           source: 'acuminous/yadda',                     target: '~0.15.4' },
+      { name: 'yadda',           source: 'acuminous/yadda',                     target: '*' },
     ]);
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-yadda",
   "dependencies": {
-    "ember": "1.13.7",
+    "ember": "1.13.13",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
@@ -11,6 +11,6 @@
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
-    "yadda": "acuminous/yadda#~0.15.4"
+    "yadda": "acuminous/yadda#~0.17.6"
   }
 }

--- a/index.js
+++ b/index.js
@@ -155,7 +155,11 @@ module.exports = {
   },
   included: function(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/yadda/dist/yadda-0.15.4.js', { type: 'test' });
+
+    var options = app.options['ember-cli-yadda'] || {};
+    var yaddaVersion = options.yaddaVersion || '0.17.6';
+
+    app.import(app.bowerDirectory + '/yadda/dist/yadda-' + yaddaVersion + '.js', { type: 'test' });
   },
   isDevelopingAddon: function() {
    return true;


### PR DESCRIPTION
The yadda version used is outdated and hardcoded, this change updates it and makes it an configuration option in your `ember-cli-build.js`.