### PR TITLE
stepname is in `this` we shouldnt hide it with an arrow function

### DIFF
--- a/blueprints/mocha/ember-cli-yadda/files/tests/acceptance/steps/steps.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/acceptance/steps/steps.js
@@ -2,12 +2,12 @@ import yadda from '../../helpers/yadda';
 
 export default function() {
   return yadda.localisation.English.library()
-    .given('I type "Ember g feature make-feature"', (next) => {
+    .given('I type "Ember g feature make-feature"', function(next) {
       visit('/');
       // Add your own assert library
       andThen(() => next());
     })
-    .when('I look in the folder', (next) => {
+    .when('I look in the folder', function(next) {
       // Add your own assert library
       next();
     });

--- a/blueprints/mocha/feature/files/tests/acceptance/steps/__folder__/__name__-steps.js
+++ b/blueprints/mocha/feature/files/tests/acceptance/steps/__folder__/__name__-steps.js
@@ -5,7 +5,7 @@ import steps from '<%= foldersUp %>steps';
 
 export default function() {
   return steps()
-    .then('I should find a file', (next) => {
+    .then('I should find a file', function(next) {
       // Add your own assert library
       next();
     });

--- a/blueprints/qunit/ember-cli-yadda/files/tests/acceptance/steps/steps.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/acceptance/steps/steps.js
@@ -2,12 +2,12 @@ import yadda from '../../helpers/yadda';
 
 export default function(assert) {
   return yadda.localisation.English.library()
-    .given('I type "Ember g feature make-feature"', (next) => {
+    .given('I type "Ember g feature make-feature"', function(next) {
       visit('/');
       assert.ok(true, this.step);
       andThen(() => next());
     })
-    .when('I look in the folder', (next) => {
+    .when('I look in the folder', function(next) {
       assert.ok(true, this.step);
       next();
     });

--- a/blueprints/qunit/feature/files/tests/acceptance/steps/__folder__/__name__-steps.js
+++ b/blueprints/qunit/feature/files/tests/acceptance/steps/__folder__/__name__-steps.js
@@ -5,7 +5,7 @@ import steps from '<%= foldersUp %>steps';
 
 export default function(assert) {
   return steps(assert)
-    .then('I should find a file', (next) => {
+    .then('I should find a file', function(next) {
       assert.ok(true, this.step);
       next();
     });


### PR DESCRIPTION
This: 

``` js
.when('I look in the folder', function(next) {
  assert.ok(true, this.step);
  next();
});
```

instead of this:

``` js
.when('I look in the folder', (next) => {
  //this.step is undefined.
  assert.ok(true, this.step);
  next();
});
```

Fixes #25 
