### PR TITLE
Include yadda from npm instead of bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,22 @@ Installing ember-cli-yadda is a breeze. All you need to do is run the following 
 ember install ember-cli-yadda
 ```
 
-This adds yadda to your node modules and your bower plugins. It also adds the following files:
+##### Versions >= 0.2.0
+
+This adds the latest version of yadda to your node modules, along with [ember-browserify](https://www.npmjs.com/package/ember-browserify) (to allow yadda to run in the browser). It also adds the following files:
 
 ```
 /tests/acceptance/steps/steps.js
 /tests/unit/steps/steps.js
 ```
 
-running `ember serve` will make the test results available at `http://localhost:4200/tests`
+You may specify the version of yadda by changing it in package.json and running `npm install`.
 
-##### Specifying the yadda version
+##### Versions <= 0.1.0
 
-After installation the addon will have added the most recent yadda version to your bower dependencies. As it comes with
-all yadda releases in its dist folder, you can specify which yadda version to include in your ember-cli build:
+ember-browserify is not used.  Instead, yadda is also added to your bower dependencies.  The files listed above are also added.
+
+After installation the addon will have added the most recent yadda version to your bower dependencies. As it comes with all yadda releases in its dist folder, you can specify which yadda version to include in your ember-cli build:
 
 ```js
 // ember-cli-build.js
@@ -38,6 +41,17 @@ all yadda releases in its dist folder, you can specify which yadda version to in
     });
 
 ```
+
+Running `ember serve` will make the test results available at `http://localhost:4200/tests`.
+
+##### Upgrading from <= 0.1.0 to >= 0.2.0
+1. Un-install yadda from your bower dependencies: `bower uninstall yadda --save`.
+2. Install ember-cli-yadda: `ember install ember-cli-yadda`.
+3. If a specific version of yadda is being used:
+    * Remove the code from ember-cli-build.js that specifies the version.
+    * Un-install the latest version of yadda from npm: `npm uninstall yadda --save-dev`.
+    * Install the desired version of yadda: `npm install yadda@<desired version> --save-dev`.
+
 
 ## Usage
 This ember-cli addon provides you with two blueprints with which you can create feature files.

--- a/blueprints/main-index.js
+++ b/blueprints/main-index.js
@@ -2,21 +2,11 @@ module.exports = {
   name: 'ember-cli-yadda',
   description: 'ember-cli-yadda',
   normalizeEntityName: function() {
-    // this prevents an error when the entityName is
-    // not specified (since that doesn't actually matter
-    // to us
   },
-
-  // locals: function(options) {
-  //   // Return custom template variables here.
-  //   return {
-  //     foo: options.entity.options.foo
-  //   };
-  // }
-
   afterInstall: function() {
-    return this.addBowerPackagesToProject([
-      { name: 'yadda',           source: 'acuminous/yadda',                     target: '*' },
-    ]);
+    return this.addPackageToProject('yadda')
+    .then(()=> {
+      return this.addAddonToProject('ember-browserify');
+    });
   }
 };

--- a/blueprints/mocha/ember-cli-yadda/files/tests/helpers/yadda.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/helpers/yadda.js
@@ -1,0 +1,2 @@
+import yadda from 'npm:yadda';
+export default yadda;

--- a/blueprints/qunit/ember-cli-yadda/files/tests/helpers/yadda.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/helpers/yadda.js
@@ -1,0 +1,2 @@
+import yadda from 'npm:yadda';
+export default yadda;

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "ember-resolver": "~0.1.20",
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
-    "qunit": "~1.20.0",
-    "yadda": "acuminous/yadda#~0.17.6"
+    "qunit": "~1.20.0"
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,5 +2,10 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {
+    //merged with the consuming application's ENV
+    browserify: {
+      tests: true
+    }
+ };
 };

--- a/index.js
+++ b/index.js
@@ -155,13 +155,5 @@ module.exports = {
   },
   included: function(app) {
     this._super.included(app);
-
-    var options = app.options['ember-cli-yadda'] || {};
-    var yaddaVersion = options.yaddaVersion || '0.17.6';
-
-    app.import(app.bowerDirectory + '/yadda/dist/yadda-' + yaddaVersion + '.js', { type: 'test' });
-  },
-  isDevelopingAddon: function() {
-   return true;
   }
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "ember-browserify": "1.1.13",
     "ember-cli": "1.13.15",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -31,14 +32,14 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-suave": "1.2.3 ",
-    "ember-try": "~0.0.8"
+    "ember-try": "~0.0.8",
+    "yadda": "^0.22.1"
   },
   "dependencies": {
     "broccoli-filter": "^1.2.2",
     "ember-cli": "^1.13.15",
     "ember-cli-babel": "^5.1.5",
-    "inflected": "^1.1.6",
-    "yadda": "^0.15.4"
+    "inflected": "^1.1.6"
   },
   "keywords": [
     "ember-addon",

--- a/test-support/helpers/yadda.js
+++ b/test-support/helpers/yadda.js
@@ -1,1 +1,0 @@
-export default require('yadda');

--- a/tests/helpers/yadda.js
+++ b/tests/helpers/yadda.js
@@ -1,0 +1,3 @@
+// needed for dummy app to run
+import yadda from 'npm:yadda';
+export default yadda;


### PR DESCRIPTION
This intent of this is to resolve issue #30.  At high level, the change is to use ember-browserify to allow yadda to be pulled in as an npm dependency rather than a bower dependency.  This eliminates  the use of the bower dependency that is distributed as a browserified module that overrides the global ```require()``` needed by ember.   The yadda npm package does change ember's ```require()```.

Summary of changes:
1. At install time, do not add yadda bower to the project, but rather add yadda npm package and ember-browserify add-on.
1. At install time add tests/helpers/yadda.js to the consuming application from the build print files.
1. Set the ember-browserify tests project to true so it looks at the test tree to browserify the yadda package.  This is merged with the consuming applications enviroment.js.
1. Add the yadda test helper in the dummy app so it can find the yadda package.

I did not update the readme.md, but will if this pull request is accepted.
