### PR TITLE
Fix package.json: remove ember-cli from dependencies (only devDependendies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "broccoli-filter": "^1.2.2",
-    "ember-cli": "^1.13.15",
     "ember-cli-babel": "^5.1.5",
     "inflected": "^1.1.6"
   },


### PR DESCRIPTION
When updating ember-cli (https://github.com/curit/ember-cli-yadda/commit/dbe3c7c412f20436131d6300683ef24bf8a971ad) in has been added to the dependencies unfortunately, instead of just the devDependencies. Sorry about that!