### PR TITLE
Mocha separate steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ This will generate the following files in your project directory:
 /tests/acceptance/make-a-feature.feature
 ```
 
+When using Mocha as your test framework, you have the option to run each scenario's step as a separate test, with all steps grouped within a Mocha `describe` block. If a step is failing, all following steps of that scenario will then be marked as pending. This way you get a much clearer picture on where (which step) a possible failure is happening. To opt in into that mode, use the `separateSteps` config option. 
+ 
+ ```js
+ // ember-cli-build.js
+ 
+     var app = new EmberApp({
+         'ember-cli-yadda': {
+             'separateSteps': true
+         }
+     });
+ 
+ ```
+ 
+ *Note that this mode is currently not available when you are using QUnit as your test framework!*
+
 ##### Unit tests
 To create a unit test, you can use ``ember g feature-unit [feature title]`` which generates a feature and step definition file where you can write your unit tests.
 

--- a/index.js
+++ b/index.js
@@ -1,148 +1,8 @@
-var yadda = require('yadda');
-var Filter = require('broccoli-filter');
-var path = require('path');
-var inflected = require('inflected');
-
 /* jshint node: true */
 'use strict';
 
-// voorbeeld van de brocolli-filter readme. bah en bah
-FeatureParser.prototype = Object.create(Filter.prototype);
-FeatureParser.prototype.constructor = FeatureParser;
-function FeatureParser(inputNode, testFramework) {
-  this.testFramework = testFramework;
-  Filter.call(this, inputNode);
-}
-FeatureParser.prototype.extensions = ['feature', 'spec', 'specification'];
-FeatureParser.prototype.targetExtension = 'js';
-FeatureParser.prototype.processString = function(content, relativePath) {
-  var feature = new yadda.parsers.FeatureParser().parse(content);
-  var basePath = relativePath.split('/').slice(0,2).join('/');
-  var nestedPath = relativePath.split('/').length > 4 ? relativePath.split('/').slice(3,-1).join('/') + '/' : '';
-  var fileName = relativePath.split('/').slice(-1)[0].split('.')[0]; //remove extension
-
-  var unitIndex = relativePath.split('/').indexOf('unit');
-  var testType = unitIndex === -1? 'acceptance' : 'unit'; // Find if the current test is an acceptance or unit test
-  var unitType = testType === 'unit'? relativePath.split('/').slice(unitIndex+1,unitIndex+2)[0] : false;
-  var unitModule = testType === 'unit'? inflected.singularize(unitType)+':'+fileName : false;
-  var stepsPath = basePath + "/"+testType+"/steps/" ;
-
-  var head = [
-    "import Ember from 'ember';",
-    this.getTestFrameworkImport(),
-    "import yadda from '" + basePath + "/helpers/yadda';",
-    "import * as library from '" + stepsPath + nestedPath + fileName + "-steps';",
-    "import startApp from '" + basePath + "/helpers/start-app';",
-    "import destroyApp from '" + basePath + "/helpers/destroy-app';",
-    "",
-    this.getTestFeature(unitModule, fileName),
-    "",
-    "testFeature("
-  ].join('\n');
-  var foot = ');';
-
-  return head + JSON.stringify(feature, null, 2) + foot;
-};
-FeatureParser.prototype.getDestFilePath = function (relativePath) {
-  var ext = path.extname(relativePath);
-  if(ext === '.feature' || ext === '.spec' || ext === '.specifiation') {
-    return relativePath.replace(ext, '-test.js');
-  }
-  return null;
-};
-FeatureParser.prototype.getTestFrameworkImport = function() {
-  switch (this.testFramework) {
-    case 'mocha':
-      return 'import { after, before, describe, it } from \'mocha\';';
-    default: // qunit
-      return 'import { moduleFor, moduleForComponent, test } from \'ember-qunit\';\
-              import { module } from \'qunit\';';
-  }
-};
-FeatureParser.prototype.getTestFeature = function(unitModule,fileName) {
-  var testFeature;
-  switch (this.testFramework) {
-    case 'mocha':
-      testFeature = [
-        "function testFeature(feature) {",
-        "  describe(`Feature: ${feature.title}`, () => {",
-        "    feature.scenarios.forEach(function(scenario) {",
-        "      describe(`Scenario: ${scenario.title}`, function() {",
-        "        before(function() {",
-        "          this.application = startApp();",
-        "        });",
-        "        after(function() {",
-        "          destroyApp(this.application);",
-        "        });",
-        "        let context = { ctx: {} };",
-        "        let failed = false;",
-        "        scenario.steps.forEach(function(step) {",
-        "          it(step, function() {",
-        "            if (failed === true) {",
-        "              this.test.pending = true;",
-        "              this.skip();",
-        "            } else {",
-        "              let self = this;",
-        "              let promise = new Ember.RSVP.Promise(function(resolve) { yadda.Yadda(library.default(), self).yadda(step, context, resolve); });",
-        "              promise.catch(function() {",
-        "                failed = true;",
-        "              });",
-        "              return promise;",
-        "            }",
-        "          });",
-        "        });",
-        "      });",
-        "    });",
-        "  });",
-        "};"
-      ];
-      break;
-    default: // qunit
-      if(unitModule && unitModule.indexOf('component') === 0) {
-        testFeature = [
-          "function testFeature(feature) {",
-          "  moduleForComponent('"+fileName+"', `Feature: ${feature.title}`, {",
-          "     unit:true,",
-          "     needs: feature.annotations.needs? feature.annotations.needs.split(',') : [],",
-          "});",
-
-          "  feature.scenarios.forEach(function(scenario) {",
-          "    test(`Scenario: ${scenario.title}`, function(assert) {",
-          "      let self = this;",
-          "      return new Ember.RSVP.Promise(function(resolve){ yadda.Yadda(library.default(assert), self).yadda(scenario.steps, { ctx: {} }, resolve); });",
-          "    });",
-          "  });",
-          "};"
-        ];
-      } else if(unitModule && unitModule.indexOf('model') === 0) {
-        // TODO: Implement unit test for models
-        // use moduleForModel
-      } else if(unitModule) {
-        // TODO: Implement unit test for generic classes
-        // use moduleFor
-      } else {
-        testFeature = [
-          "function testFeature(feature) {",
-          "  module(`Feature: ${feature.title}`, {",
-          "    beforeEach: function() {",
-          "      this.application = startApp();",
-          "    },",
-          "    afterEach: function() {",
-          "      destroyApp(this.application);",
-          "    }",
-          "  });",
-
-          "  feature.scenarios.forEach(function(scenario) {",
-          "    test(`Scenario: ${scenario.title}`, function(assert) {",
-          "      return new Ember.RSVP.Promise(function (resolve) { yadda.Yadda(library.default(assert), this).yadda(scenario.steps, { ctx: {} }, resolve); });",
-          "    });",
-          "  });",
-          "};"
-        ];
-      }
-  }
-  return testFeature.join('\n');
-};
+var path = require('path');
+var FeatureParser = require('./lib/feature-parser');
 
 module.exports = {
   name: 'ember-cli-yadda',
@@ -156,11 +16,12 @@ module.exports = {
   },
   setupPreprocessorRegistry: function(type, registry) {
     var testFramework = this.getTestFramework();
+    var self = this;
     registry.add('js', {
       name: 'ember-cli-yadda',
       ext: ['feature', 'spec', 'specification'],
       toTree: function(tree, inputPath, outputPath) {
-        return new FeatureParser(tree, testFramework);
+        return new FeatureParser(tree, testFramework, self.options);
       }
     });
   },
@@ -169,5 +30,6 @@ module.exports = {
   },
   included: function(app) {
     this._super.included(app);
+    this.options = app.options['ember-cli-yadda'] || {};
   }
 };

--- a/lib/feature-parser.js
+++ b/lib/feature-parser.js
@@ -1,0 +1,95 @@
+/* jshint node: true */
+'use strict';
+
+var yadda = require('yadda');
+var Filter = require('broccoli-filter');
+var fs = require('fs');
+var path = require('path');
+var inflected = require('inflected');
+
+// voorbeeld van de brocolli-filter readme. bah en bah
+FeatureParser.prototype = Object.create(Filter.prototype);
+FeatureParser.prototype.constructor = FeatureParser;
+function FeatureParser(inputNode, testFramework, options) {
+  this.testFramework = testFramework;
+  this.testRunnerCache = {};
+  this.options = options;
+  Filter.call(this, inputNode);
+}
+FeatureParser.prototype.extensions = ['feature', 'spec', 'specification'];
+FeatureParser.prototype.targetExtension = 'js';
+FeatureParser.prototype.processString = function(content, relativePath) {
+  var feature = new yadda.parsers.FeatureParser().parse(content);
+  var basePath = relativePath.split('/').slice(0,2).join('/');
+  var nestedPath = relativePath.split('/').length > 4 ? relativePath.split('/').slice(3,-1).join('/') + '/' : '';
+  var fileName = relativePath.split('/').slice(-1)[0].split('.')[0]; //remove extension
+
+  var unitIndex = relativePath.split('/').indexOf('unit');
+  var testType = unitIndex === -1? 'acceptance' : 'unit'; // Find if the current test is an acceptance or unit test
+  var unitType = testType === 'unit'? relativePath.split('/').slice(unitIndex+1,unitIndex+2)[0] : false;
+  var unitModule = testType === 'unit'? inflected.singularize(unitType)+':'+fileName : false;
+  var stepsPath = basePath + "/"+testType+"/steps/" ;
+
+  var head = [
+    "import Ember from 'ember';",
+    this.getTestFrameworkImport(),
+    "import yadda from '" + basePath + "/helpers/yadda';",
+    "import * as library from '" + stepsPath + nestedPath + fileName + "-steps';",
+    "import startApp from '" + basePath + "/helpers/start-app';",
+    "import destroyApp from '" + basePath + "/helpers/destroy-app';",
+    "",
+    this.getTestFeature(unitModule),
+    "",
+    "testFeature("
+  ].join('\n');
+  var foot = ');';
+
+  return head + JSON.stringify(feature, null, 2) + foot;
+};
+FeatureParser.prototype.getDestFilePath = function (relativePath) {
+  var ext = path.extname(relativePath);
+  if(ext === '.feature' || ext === '.spec' || ext === '.specifiation') {
+    return relativePath.replace(ext, '-test.js');
+  }
+  return null;
+};
+FeatureParser.prototype.getTestFrameworkImport = function() {
+  switch (this.testFramework) {
+    case 'mocha':
+      return 'import { after, before, describe, it } from \'mocha\';';
+    default: // qunit
+      return 'import { moduleFor, moduleForComponent, test } from \'ember-qunit\';\
+              import { module } from \'qunit\';';
+  }
+};
+
+FeatureParser.prototype.getTestRunnerSource = function(testType) {
+  if (typeof this.testRunnerCache[testType] === 'undefined') {
+    var filePath = path.join(__dirname, './test-runner', this.testFramework);
+    if (this.options.separateSteps === true) {
+      filePath = path.join(filePath, 'separate');
+    }
+    var file = path.join(filePath, testType + '.js');
+
+    if (!fs.existsSync(file)) {
+      throw new Error('No test runner is currently available for ' + testType + ' tests with ' + this.testFramework + '. Missing file: ' + file);
+    }
+
+    this.testRunnerCache[testType] = fs.readFileSync(file);
+  }
+  return this.testRunnerCache[testType];
+};
+
+FeatureParser.prototype.getTestFeature = function(unitModule) {
+  if(unitModule && unitModule.indexOf('component') === 0) {
+    return this.getTestRunnerSource('component');
+  } else if(unitModule && unitModule.indexOf('model') === 0) {
+    return this.getTestRunnerSource('model');
+  } else if(unitModule) {
+    return this.getTestRunnerSource('unit');
+  } else {
+    return this.getTestRunnerSource('acceptance');
+  }
+};
+
+module.exports = FeatureParser;

--- a/lib/test-runner/mocha/acceptance.js
+++ b/lib/test-runner/mocha/acceptance.js
@@ -1,0 +1,17 @@
+function testFeature(feature) {
+  describe(`Feature: ${feature.title}`, () => {
+    beforeEach(function() {
+      this.application = startApp();
+    });
+    afterEach(function() {
+      destroyApp(this.application);
+    });
+    
+    feature.scenarios.forEach(function(scenario) {
+      it(`Scenario: ${scenario.title}`, function() {
+        let self = this;
+        return new Ember.RSVP.Promise(function(resolve) { yadda.Yadda(library.default(), self).yadda(scenario.steps, { ctx: {} }, resolve); });
+      });
+    });
+  });
+};

--- a/lib/test-runner/mocha/separate/acceptance.js
+++ b/lib/test-runner/mocha/separate/acceptance.js
@@ -1,0 +1,31 @@
+function testFeature(feature) {
+  describe(`Feature: ${feature.title}`, () => {
+    feature.scenarios.forEach(function(scenario) {
+      describe(`Scenario: ${scenario.title}`, function() {
+        before(function() {
+          this.application = startApp();
+        });
+        after(function() {
+          destroyApp(this.application);
+        });
+        let context = { ctx: {} };
+        let failed = false;
+        scenario.steps.forEach(function(step) {
+          it(step, function() {
+            if (failed === true) {
+              this.test.pending = true;
+              this.skip();
+            } else {
+              let self = this;
+              let promise = new Ember.RSVP.Promise(function(resolve) { yadda.Yadda(library.default(), self).yadda(step, context, resolve); });
+              promise.catch(function() {
+                failed = true;
+              });
+              return promise;
+            }
+          });
+        });
+      });
+    });
+  });
+}

--- a/lib/test-runner/qunit/acceptance.js
+++ b/lib/test-runner/qunit/acceptance.js
@@ -1,0 +1,16 @@
+function testFeature(feature) {
+  module(`Feature: ${feature.title}`, {
+    beforeEach: function() {
+      this.application = startApp();
+    },
+    afterEach: function() {
+      destroyApp(this.application);
+    }
+  });
+
+  feature.scenarios.forEach(function(scenario) {
+    test(`Scenario: ${scenario.title}`, function(assert) {
+      return new Ember.RSVP.Promise(function (resolve) { yadda.Yadda(library.default(assert), this).yadda(scenario.steps, { ctx: {} }, resolve); });
+    });
+  });
+};

--- a/lib/test-runner/qunit/component.js
+++ b/lib/test-runner/qunit/component.js
@@ -1,0 +1,13 @@
+function testFeature(feature) {
+  moduleForComponent('"+fileName+"', `Feature: ${feature.title}`, {
+     unit:true,
+     needs: feature.annotations.needs? feature.annotations.needs.split(',') : [],
+  });
+
+  feature.scenarios.forEach(function(scenario) {
+    test(`Scenario: ${scenario.title}`, function(assert) {
+      let self = this;
+      return new Ember.RSVP.Promise(function(resolve){ yadda.Yadda(library.default(assert), self).yadda(scenario.steps, { ctx: {} }, resolve); });
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.4",
+    "ember-cli-qunit": "^2.2.1",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",


### PR DESCRIPTION
@albertjan So finally here is the PR that implements #33! :)

I tried to implement the same separated steps thing for QUnit, but that failed because of:

- it would have required QUnit 2, because only then the required `before` and `after` hooks were introduced, but to use QUnit2 this would require using ember-cli-qunit 3, which has some requirement on some more recent ember-cli version (2.4 IIRC)

- there does not seem a way to tell QUnit during *runtime* that a test should be regarded as pending, as it is the case with the Mocha implementation. You can only statically declare a step as pending (Skip API: https://api.qunitjs.com/QUnit.skip/). But this would be required to mark all following steps (which are then separate tests) as pending in the case that during runtime the preceding test/step would fail.

Therefor this feature is missing for QUnit. To make this not behave differently for QUnit and Mocha by default and to still allow the "old" way, I added the new behaviour as an option. So without using the `separateSteps` option described in the Readme, this should be fully backwards compatible.

I refactored the `index.js` a little bit, as it would have become quit large and cluttered. And writing the generated test runners as code within strings also felt a bit awkward. Should look better now!