### PR TITLE
Add broccoli-persistent-filter to improve rebuild times

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ module.exports = {
   },
   included: function(app) {
     this._super.included(app);
-    this.options = app.options['ember-cli-yadda'] || {};
+    var options = app.options['ember-cli-yadda'] || {};
+    if (typeof options.persist === 'undefined') {
+      options.persist = true;
+    }
+    this.options = options;
   }
 };

--- a/lib/feature-parser.js
+++ b/lib/feature-parser.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var yadda = require('yadda');
-var Filter = require('broccoli-filter');
+var Filter = require('broccoli-persistent-filter');
 var fs = require('fs');
 var path = require('path');
 var inflected = require('inflected');

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-try": "~0.0.8"
   },
   "dependencies": {
-    "broccoli-filter": "^1.2.2",
+    "broccoli-persistent-filter": "^1.4.3",
     "ember-cli-babel": "^5.1.5",
     "inflected": "^1.1.6",
     "yadda": "*"


### PR DESCRIPTION
I noticed that `FeatureParser` was a slow tree on rebuilds after touching files unrelated to our acceptance tests.

Upgrading to `broccoli-persistent-filter` and enabling caching by default should improve rebuild times and hot builds.

See https://github.com/joliss/broccoli-coffee/issues/14